### PR TITLE
Buildx cache

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -8,6 +8,10 @@ on:
       - "main"
     tags:
       - v*
+    paths:
+      - "dockerfiles/**"
+    paths-ignore:
+      - "*.md"
 
 env:
   # TODO Variableization of image name

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,8 +10,6 @@ on:
       - v*
     paths:
       - "dockerfiles/**"
-    paths-ignore:
-      - "*.md"
 
 env:
   # TODO Variableization of image name

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -63,6 +71,16 @@ jobs:
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
- Use Buildx cache to reduce build time. #4
- Add conditions that does not start the workflow. 