### PR TITLE
add here package

### DIFF
--- a/scripts/install_editorsupports.sh
+++ b/scripts/install_editorsupports.sh
@@ -8,6 +8,7 @@ INSTALL_RADIAN=${1:-"true"}
 INSTALL_DEVTOOLS=${2:-"true"}
 INSTALL_LANGUAGESERVER=${3:-"true"}
 INSTALL_HTTPGD=${4:-"true"}
+INSTALL_HERE=${5:-"true"}
 
 ## The httpgd package had not be able to be installed from CRAN before R 4.0.3 release
 if [ "${R_VERSION}" = "4.0.0" ] || [ "${R_VERSION}" = "4.0.1" ] || [ "${R_VERSION}" = "4.0.2" ]; then
@@ -72,6 +73,12 @@ if [ "${INSTALL_HTTPGD}" = "true" ]; then
         libfontconfig1-dev"
     R_PACKAGES="${R_PACKAGES=} \
         httpgd"
+fi
+
+## Add httpgd dependencies and httpgd to the list
+if [ "${INSTALL_HERE}" = "true" ]; then
+    R_PACKAGES="${R_PACKAGES=} \
+        here"
 fi
 
 # Install packages


### PR DESCRIPTION
When executing code written in a RMarkdown file, the [`here`](https://github.com/r-lib/here) package is useful for editors that do not have the ability to automatically change the working directory like RStudio.